### PR TITLE
added lazy args

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,9 @@ function gulpSpawn(options) {
 			file.shortened = options.filename(base, ext);
 			file.path = path.join(dir, file.shortened);
 		}
+		if (options.args && typeof options.args === "function") {
+			options.args = options.args(file);
+		}
 
 		// spawn program
 		var program = cp.spawn(options.cmd, options.args);

--- a/index.js
+++ b/index.js
@@ -33,12 +33,10 @@ function gulpSpawn(options) {
 			file.shortened = options.filename(base, ext);
 			file.path = path.join(dir, file.shortened);
 		}
-		if (options.args && typeof options.args === "function") {
-			options.args = options.args(file);
-		}
+		var args = options.args && typeof options.args === "function" ? options.args(file) : options.args;
 
 		// spawn program
-		var program = cp.spawn(options.cmd, options.args);
+		var program = cp.spawn(options.cmd, args);
 
 		// listen to stderr and emit errors if any
 		var errBuffer = new Buffer(0);


### PR DESCRIPTION
Some tools don't accept input streams, they accept filenames. I added lazy args initialization.
Just use a function instead of array.
