### PR TITLE
feat: allow options argument to spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ gulp.src("./src/images/*.{jpg,png,gif}", { buffer: false })
 			"-"
 		],
 		// optional
+		opts: { cwd: "." },
 		filename: function(base, ext) {
 			return base + "-half" + ext;
 		}

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function gulpSpawn(options) {
 		}
 
 		// spawn program
-		var program = cp.spawn(options.cmd, options.args);
+		var program = cp.spawn(options.cmd, options.args, options.opts);
 
 		// listen to stderr and emit errors if any
 		var errBuffer = new Buffer(0);


### PR DESCRIPTION
This allows setting all values child_process.spawn supports, such as cwd
and environment variables.

This also fixes #10 and #12.
