### PR TITLE
Add can build args option

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,18 @@ var cp = require("child_process"),
 	path = require("path"),
 	Duplexer = require("plexer"),
 	Stream = require("stream"),
-	gUtil = require("gulp-util");
+	gUtil = require("gulp-util"),
+	_ = require("underscore");
 
 var PLUGIN_NAME = "gulp-spawn";
+
+function buildArgs(file, args) {
+	"use strict";
+
+	if (!_.isFunction(args)) return args;
+
+	return args(file);
+}
 
 function gulpSpawn(options) {
 	"use strict";
@@ -35,7 +44,7 @@ function gulpSpawn(options) {
 		}
 
 		// spawn program
-		var program = cp.spawn(options.cmd, options.args);
+		var program = cp.spawn(options.cmd, buildArgs(file, options.args));
 
 		// listen to stderr and emit errors if any
 		var errBuffer = new Buffer(0);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   ],
   "dependencies": {
     "gulp-util": "~2.2.14",
-    "plexer": "0.0.1"
+    "plexer": "0.0.1",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "mocha": "*",

--- a/tests/buildArgs.js
+++ b/tests/buildArgs.js
@@ -1,0 +1,135 @@
+/*global describe, it, beforeEach */
+"use strict";
+
+var gSpawn = require("../"),
+	path = require("path"),
+	Stream = require("stream"),
+	gutil = require("gulp-util"),
+	assert = require("assert"),
+	es = require("event-stream");
+
+describe("gulp-spawn", function () {
+
+	describe("build args", function () {
+
+		it("should work with args array", function (done) {
+
+			var stream = gSpawn({
+				cmd: "cat",
+				args: ["-n"]
+			});
+
+			var inputStream = new Stream.PassThrough({objectMode: true}),
+				outputStream = new Stream.PassThrough({objectMode: true});
+
+			var fakeFile = new gutil.File({
+				cwd: "./",
+				base: "test",
+				path: "test/file.js",
+				contents: new Buffer("line1\nline2")
+			});
+
+			inputStream
+				.pipe(stream)
+				.pipe(outputStream);
+
+			outputStream.on("readable", function () {
+				var newFile;
+				while (newFile = outputStream.read()) {
+					var text = newFile.contents.toString();
+					assert.equal(text, "     1\tline1\n     2\tline2");
+				}
+			});
+
+			outputStream.on("end", function () {
+				done();
+			});
+
+			inputStream.write(fakeFile);
+			inputStream.end();
+
+		});
+
+		it("should work with return args array function", function (done) {
+
+			var stream = gSpawn({
+				cmd: "cat",
+				args: function () { return ["-n"]; }
+			});
+
+			var inputStream = new Stream.PassThrough({objectMode: true}),
+				outputStream = new Stream.PassThrough({objectMode: true});
+
+			var fakeFile = new gutil.File({
+				cwd: "./",
+				base: "test",
+				path: "test/file.js",
+				contents: new Buffer("line1\nline2")
+			});
+
+			inputStream
+				.pipe(stream)
+				.pipe(outputStream);
+
+			outputStream.on("readable", function () {
+				var newFile;
+				while (newFile = outputStream.read()) {
+					var text = newFile.contents.toString();
+					assert.equal(text, "     1\tline1\n     2\tline2");
+				}
+			});
+
+			outputStream.on("end", function () {
+				done();
+			});
+
+			inputStream.write(fakeFile);
+			inputStream.end();
+
+		});
+
+		it("should work with return args array function, and hand over file info", function (done) {
+
+			var stream = gSpawn({
+				cmd: "sed",
+				args: function (file) {
+					var basename = path.basename(file.path);
+					return ["s/line/" + basename + "/"];
+				}
+			});
+
+			var inputStream = new Stream.PassThrough({objectMode: true}),
+				outputStream = new Stream.PassThrough({objectMode: true});
+
+			var fakeFile = new gutil.File({
+				cwd: "./",
+				path: "test/file.js",
+				base: "test",
+				basename: "file.js",
+				contents: new Buffer("line1\nline2")
+			});
+
+			inputStream
+				.pipe(stream)
+				.pipe(outputStream);
+
+			outputStream.on("readable", function () {
+				var newFile;
+				while (newFile = outputStream.read()) {
+					var text = newFile.contents.toString();
+					assert.equal(text, "file.js1\nfile.js2");
+				}
+			});
+
+			outputStream.on("end", function () {
+				done();
+			});
+
+			inputStream.write(fakeFile);
+			inputStream.end();
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
I wan to use `File object` properties, when invoke spawn,

```javascript
  gulp.src('book/index.adoc')
    .pipe(spawn({
      cmd: 'asciidoctor-pdf',
      args: file => ['-B', file.base, '-b', 'pdf', '-o-', '-'], // Change base directory to 'book'
      filename: basename => `${basename}.pdf`,
    }))
    .pipe(gulp.dest('dist'));
```